### PR TITLE
Fix Everstone & Synchronize being wiped out by Shiny Charm re-rolls; decide egg shininess once, at hatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,21 +96,25 @@ In-game milestones for Shiny Charm acquisition (all added to Player Item PC, max
   * do not work if left or stored in the player's item PC.
 * Shiny Charms only take effect if they are in the player's bag.
 * Shiny Charms cannot be tossed.
-* Breeding Eggs from Daycare are impacted by Shiny Charm(s) as long as they're in the bag when you collect the egg.
+* Breeding Eggs from Daycare are impacted by Shiny Charm(s) as long as they're in the bag when the Egg hatches. (An Egg's shininess is decided when it hatches, against the hatching player's Trainer ID, so traded Eggs shine for their new owner.)
 * Shiny Charms can be held by Pokémon and therefore traded between different Emerald Legacy Enhanced games.
   * do not change Shiny changes if held by a Pokémon
 * If migrating a save and already completed a relevant milestone, the Shiny Charm will be added to your PC, except for the Pokédex Shiny Charms which require the above noted in-game tasks to be added to the PC.
 
 **Shiny Charm Rates:**
+
+Each shiny roll is 1/8192. With at least one Shiny Charm in the bag, the game performs (Charms + 1) × 8 rolls per Pokémon, keeping the first shiny result:
 * 0 Charms - 1/8192 (No Shiny Charms in bag) - 0.01221% - Same as original Emerald
-1. 1/1024 (Available from Start of Game) - 0.09766%
-2. 1/512  - 0.1953%
-3. 3/1024 - 0.2930% (I suspect most people will end up here by end of their main playthrough)
-4. 1/256  - 0.3906%
-5. 5/1024 - 0.4883%
-6. 3/512  - 0.5859%
-7. 7/1024 - 0.6836%
-8. 1/128  - 0.7812%
+1. 1/512  (Available from Start of Game) - 0.1953%
+2. 3/1024 - 0.2930%
+3. 1/256  - 0.3906% (I suspect most people will end up here by end of their main playthrough)
+4. 5/1024 - 0.4883%
+5. 3/512  - 0.5859%
+6. 7/1024 - 0.6836%
+7. 1/128  - 0.7812%
+8. 9/1024 - 0.8789%
+
+Daycare/gift Eggs (rolled when they hatch) and Synchronize/Cute Charm influenced encounters additionally keep their own natural 1/8192 chance on top of the charm rolls above.
 
 ### Comprehensive Implemented Changes
 

--- a/src/daycare.c
+++ b/src/daycare.c
@@ -914,8 +914,16 @@ void CreateEgg(struct Pokemon *mon, u16 species, bool8 setHotSpringsLocation)
     u8 language;
     u8 metLocation;
     u8 isEgg;
+    u32 otId;
 
-    CreateMon(mon, species, EGG_HATCH_LEVEL, USE_RANDOM_IVS, FALSE, 0, OT_ID_PLAYER_ID, 0);
+    // Gift Eggs roll no shininess here either: like daycare Eggs, their single
+    // shiny window is at hatch (CreateHatchedMon). The OT is identical to
+    // OT_ID_PLAYER_ID.
+    otId = gSaveBlock2Ptr->playerTrainerId[0]
+         | (gSaveBlock2Ptr->playerTrainerId[1] << 8)
+         | (gSaveBlock2Ptr->playerTrainerId[2] << 16)
+         | (gSaveBlock2Ptr->playerTrainerId[3] << 24);
+    CreateMon(mon, species, EGG_HATCH_LEVEL, USE_RANDOM_IVS, FALSE, 0, OT_ID_PRESET, otId);
     metLevel = 0;
     ball = ITEM_POKE_BALL;
     language = LANGUAGE_JAPANESE;
@@ -937,12 +945,21 @@ void CreateEgg(struct Pokemon *mon, u16 species, bool8 setHotSpringsLocation)
 static void SetInitialEggData(struct Pokemon *mon, u16 species, struct DayCare *daycare)
 {
     u32 personality;
+    u32 otId;
     u16 ball;
     u8 metLevel;
     u8 language;
 
     personality = daycare->offspringPersonality;
-    CreateMon(mon, species, EGG_HATCH_LEVEL, USE_RANDOM_IVS, TRUE, personality, OT_ID_PLAYER_ID, 0);
+    // Pass the player's ID as a preset OT so CreateBoxMon keeps the crafted
+    // personality untouched and grants no shiny re-rolls here: an Egg's single
+    // shiny window is at hatch (CreateHatchedMon), against the hatching
+    // player's ID. The resulting OT is identical to OT_ID_PLAYER_ID.
+    otId = gSaveBlock2Ptr->playerTrainerId[0]
+         | (gSaveBlock2Ptr->playerTrainerId[1] << 8)
+         | (gSaveBlock2Ptr->playerTrainerId[2] << 16)
+         | (gSaveBlock2Ptr->playerTrainerId[3] << 24);
+    CreateMon(mon, species, EGG_HATCH_LEVEL, USE_RANDOM_IVS, TRUE, personality, OT_ID_PRESET, otId);
     metLevel = 0;
     ball = ITEM_POKE_BALL;
     language = LANGUAGE_JAPANESE;

--- a/src/egg_hatch.c
+++ b/src/egg_hatch.c
@@ -312,7 +312,7 @@ static const s16 sEggShardVelocities[][2] =
 static void CreateHatchedMon(struct Pokemon *egg, struct Pokemon *temp)
 {
     u16 species;
-    u32 personality, pokerus, otId;
+    u32 personality, pokerus;
     u8 i, friendship, language, gameMet, markings, isModernFatefulEncounter;
     u16 moves[MAX_MON_MOVES];
     u32 ivs[NUM_STATS];
@@ -334,15 +334,11 @@ static void CreateHatchedMon(struct Pokemon *egg, struct Pokemon *temp)
     pokerus = GetMonData(egg, MON_DATA_POKERUS);
     isModernFatefulEncounter = GetMonData(egg, MON_DATA_MODERN_FATEFUL_ENCOUNTER);
 
-    // Pass the player's ID as a preset OT so CreateBoxMon skips the Shiny
-    // Charm re-roll at hatch: the Egg's personality (and thus shininess) was
-    // already decided when the Egg was generated. The resulting OT is
-    // identical to OT_ID_PLAYER_ID.
-    otId = gSaveBlock2Ptr->playerTrainerId[0]
-         | (gSaveBlock2Ptr->playerTrainerId[1] << 8)
-         | (gSaveBlock2Ptr->playerTrainerId[2] << 16)
-         | (gSaveBlock2Ptr->playerTrainerId[3] << 24);
-    CreateMon(temp, species, EGG_HATCH_LEVEL, USE_RANDOM_IVS, TRUE, personality, OT_ID_PRESET, otId);
+    // Hatching runs the Egg's single shiny window: the Egg's personality gets
+    // its natural shiny check (plus any Shiny Charm re-rolls) against the
+    // hatching player's ID, so traded Eggs shine for their new owner. Egg
+    // generation (daycare.c) rolls no shininess at all.
+    CreateMon(temp, species, EGG_HATCH_LEVEL, USE_RANDOM_IVS, TRUE, personality, OT_ID_PLAYER_ID, 0);
 
     for (i = 0; i < MAX_MON_MOVES; i++)
         SetMonData(temp, MON_DATA_MOVE1 + i,  &moves[i]);

--- a/src/egg_hatch.c
+++ b/src/egg_hatch.c
@@ -312,7 +312,7 @@ static const s16 sEggShardVelocities[][2] =
 static void CreateHatchedMon(struct Pokemon *egg, struct Pokemon *temp)
 {
     u16 species;
-    u32 personality, pokerus;
+    u32 personality, pokerus, otId;
     u8 i, friendship, language, gameMet, markings, isModernFatefulEncounter;
     u16 moves[MAX_MON_MOVES];
     u32 ivs[NUM_STATS];
@@ -334,7 +334,15 @@ static void CreateHatchedMon(struct Pokemon *egg, struct Pokemon *temp)
     pokerus = GetMonData(egg, MON_DATA_POKERUS);
     isModernFatefulEncounter = GetMonData(egg, MON_DATA_MODERN_FATEFUL_ENCOUNTER);
 
-    CreateMon(temp, species, EGG_HATCH_LEVEL, USE_RANDOM_IVS, TRUE, personality, OT_ID_PLAYER_ID, 0);
+    // Pass the player's ID as a preset OT so CreateBoxMon skips the Shiny
+    // Charm re-roll at hatch: the Egg's personality (and thus shininess) was
+    // already decided when the Egg was generated. The resulting OT is
+    // identical to OT_ID_PLAYER_ID.
+    otId = gSaveBlock2Ptr->playerTrainerId[0]
+         | (gSaveBlock2Ptr->playerTrainerId[1] << 8)
+         | (gSaveBlock2Ptr->playerTrainerId[2] << 16)
+         | (gSaveBlock2Ptr->playerTrainerId[3] << 24);
+    CreateMon(temp, species, EGG_HATCH_LEVEL, USE_RANDOM_IVS, TRUE, personality, OT_ID_PRESET, otId);
 
     for (i = 0; i < MAX_MON_MOVES; i++)
         SetMonData(temp, MON_DATA_MOVE1 + i,  &moves[i]);

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -2287,12 +2287,54 @@ void CreateBoxMon(struct BoxPokemon *boxMon, u16 species, u8 level, u8 fixedIV, 
                     itemCount++;
                 } while (CheckBagHasItem(ITEM_SHINY_CHARM, itemCount));
 
-                do
+                if (hasFixedPersonality)
                 {
-                    personality = Random32();
+                    // Everstone eggs, Synchronize and Cute Charm craft this
+                    // personality to lock in nature/gender, so it must never be
+                    // discarded: the Shiny Charm only grants extra chances for
+                    // the mon to be shiny on top of it. If the crafted
+                    // personality is already shiny, keep it as-is.
                     shinyValue = HIHALF(value) ^ LOHALF(value) ^ HIHALF(personality) ^ LOHALF(personality);
-                    rolls++;
-                } while (shinyValue >= SHINY_ODDS && rolls < maxShinyRolls);
+                    if (shinyValue >= SHINY_ODDS)
+                    {
+                        do
+                        {
+                            personality = Random32();
+                            shinyValue = HIHALF(value) ^ LOHALF(value) ^ HIHALF(personality) ^ LOHALF(personality);
+                            rolls++;
+                        } while (shinyValue >= SHINY_ODDS && rolls < maxShinyRolls);
+
+                        if (shinyValue < SHINY_ODDS)
+                        {
+                            // A charm roll hit: rebuild a shiny personality that
+                            // still has the locked nature and gender.
+                            u8 nature = GetNatureFromPersonality(fixedPersonality);
+                            u8 gender = GetGenderFromSpeciesAndPersonality(species, fixedPersonality);
+                            u16 tid = HIHALF(value) ^ LOHALF(value);
+
+                            do
+                            {
+                                personality = Random32();
+                                personality = (((tid ^ (Random() % SHINY_ODDS)) ^ LOHALF(personality)) << 16) | LOHALF(personality);
+                            } while (GetNatureFromPersonality(personality) != nature
+                                  || GetGenderFromSpeciesAndPersonality(species, personality) != gender);
+                        }
+                        else
+                        {
+                            // No shiny: restore the crafted personality untouched.
+                            personality = fixedPersonality;
+                        }
+                    }
+                }
+                else
+                {
+                    do
+                    {
+                        personality = Random32();
+                        shinyValue = HIHALF(value) ^ LOHALF(value) ^ HIHALF(personality) ^ LOHALF(personality);
+                        rolls++;
+                    } while (shinyValue >= SHINY_ODDS && rolls < maxShinyRolls);
+                }
             }
 #endif
         }


### PR DESCRIPTION
## Root cause

With at least one Shiny Charm in the bag, the charm branch in `CreateBoxMon` unconditionally re-rolled the personality of **every** `OT_ID_PLAYER_ID` Pokémon (16 rolls with one charm), ignoring `hasFixedPersonality`. Since a re-roll almost never lands a shiny (~99.8% of the time), the mon simply kept the *last random roll*  silently discarding every personality that was deliberately crafted upstream:

- **Everstone eggs**  the daycare pre-rolls a nature-matched personality (`_TriggerPendingDaycareEgg`), which was then thrown away in `SetInitialEggData`… and thrown away *again* at hatch, because `CreateHatchedMon` also re-creates the mon through the same code path.
- **Synchronize**  `PickWildMonNature` itself is vanilla-correct (the 50% roll works fine); its nature-matched personality from `CreateMonWithNature` was just being discarded afterwards.
- **Cute Charm**  same story for the forced-gender personality from `CreateMonWithGenderNatureLetter`.

## The changes

1. **`7722189e` — Respect fixed personalities in the charm branch.** If the crafted personality is already shiny, it's kept as-is. Otherwise the charm rolls only serve as extra shiny chances: on a hit, the shiny personality is rebuilt *preserving the locked nature and gender*; on a miss, the crafted personality is restored untouched. Ordinary wild/gift generation is unchanged.

2. **`f52e896e` + `eebcdd75` — Exactly one shiny window per egg, at hatch.** Eggs pass through `CreateBoxMon` twice (generation + hatch), which double-dipped the charm odds once fix #1 made shinies survive. Egg generation (`SetInitialEggData` / `CreateEgg`) now passes `OT_ID_PRESET` with the player's own ID — byte-identical OT, but no shiny logic runs — and hatching is the single window: the egg's personality gets its natural 1/8192 check plus any charm re-rolls against **the hatching player's Trainer ID**. Traded eggs therefore shine for their new owner.

3. **`fc4061fd` — Document the real Shiny Charm rates.** The charm-counting loop has always granted `(Charms + 1) × 8` re-rolls rather than `Charms × 8`. Rather than halving odds players are used to, this keeps the behavior and corrects the README table to match (1 charm = 1/512 … 8 charms = 9/1024), and updates the breeding note for the hatch-time window.

## Player-visible outcome

- Everstone passes the holder's nature to eggs again, charm in bag or not.
- Synchronize gives its 50% nature match again.
- Cute Charm's forced gender actually sticks.
- Egg shiny odds are a single honest window (natural roll + charm re-rolls at hatch) instead of overwrite-roulette; a charm-shiny egg still keeps its Everstone nature and gender.

## Testing notes

Not yet compiled on my end, should be tested: 
1. Shiny Charm in bag + Everstone parent → collected eggs should hatch with the parent's nature.
2. Shiny Charm in bag + Synchronize lead → wild natures should match ~50% of encounters.
