### PR TITLE
Stop Eggs from gaining EXP under EXP. ALL

### DIFF
--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -3469,6 +3469,21 @@ static void Cmd_getexp(void)
     case 2: // set exp value to the poke in expgetter_id and print message
         if (gBattleControllerExecFlags == 0)
         {
+            // Skip Eggs entirely. The !IS_EGG check further down only suppresses
+            // the exp computation but still advances to case 3, which emits an
+            // exp update for the Egg with whatever stale value gBattleMoveDamage
+            // holds - for an Egg in slot 0 with EXP. ALL on, that's the last
+            // damage dealt, so the Egg gained EXP and could even "level up",
+            // altering its hatch cycles (friendship) and moveset. Jump straight
+            // to case 5 like other skipped party members.
+            if (GetMonData(&gPlayerParty[gBattleStruct->expGetterMonId], MON_DATA_IS_EGG))
+            {
+                gBattleStruct->sentInPokes >>= 1;
+                gBattleScripting.getexpState = 5;
+                gBattleMoveDamage = 0;
+                break;
+            }
+
             item = GetMonData(&gPlayerParty[gBattleStruct->expGetterMonId], MON_DATA_HELD_ITEM);
 
             if (item == ITEM_ENIGMA_BERRY)


### PR DESCRIPTION
## What this fixes

Eggs receiving exp from EXP. All

## Root cause

With **EXP. ALL enabled** and an Egg in the party, `Cmd_getexp` case 2 reaches its final else-branch for the Egg (the EXP. ALL condition prevents the early skip, and an Egg can't be max level or level-capped). There, the inner `HP && !IS_EGG` guard correctly suppresses the **exp computation**, but the state machine still runs `getexpState++`, advancing to **case 3**.

Case 3 has its own guard: `HP && level != MAX_LEVEL && !levelCapped`.  Eggs carry real HP stats internally and sit at level 5. So case 3 calls:

```c
BtlController_EmitExpUpdate(BUFFER_A, expGetterMonId, gBattleMoveDamage);
```

## The fix

Case 2 now skips Eggs before anything else runs, the same way level-capped Pokémon are skipped a few branches down:

```c
if (GetMonData(&gPlayerParty[gBattleStruct->expGetterMonId], MON_DATA_IS_EGG))
{
    gBattleStruct->sentInPokes >>= 1;
    gBattleScripting.getexpState = 5;
    gBattleMoveDamage = 0;
    break;
}
```

Eggs can no longer receive EXP updates, EVs, friendship changes, moves, or level-up flags through any path in `Cmd_getexp`. The EXP distribution maths are untouched.

