### PR TITLE
Fix Feebas tiles occasionally failing to place (uninitialized slot)

### DIFF
--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -179,13 +179,21 @@ void GetFeebasTiles(void)
     u32 y;
     u32 i;
     FeebasSeedRng(gSaveBlock1Ptr->dewfordTrends[0].rand);
-    for (; nFeebasGenerated < NUM_FEEBAS_SPOTS; nFeebasGenerated++)
+    // Assign each Feebas spot to a random water tile, re-rolling on tiles
+    // 1-3: those are the inaccessible spots at the top of the map, so the
+    // first usable tile is 4. This matches vanilla Emerald, which likewise
+    // allows two spots to share a tile (there is no duplicate check). The
+    // original Legacy rewrite instead SKIPPED the assignment on a 1-3 roll
+    // while still advancing to the next spot, leaving that slot uninitialized
+    // (stack garbage) so the spot could vanish or land on a stale tile.
+    while (nFeebasGenerated < NUM_FEEBAS_SPOTS)
     {
         u32 randomTile = FeebasRandom() % nWaterTiles;
         if (randomTile == 0)
             randomTile = nWaterTiles;
-        if (randomTile == 0 || randomTile > 3)
-            feebasTiles[nFeebasGenerated] = randomTile;
+        if (randomTile <= 3)
+            continue;
+        feebasTiles[nFeebasGenerated++] = randomTile;
     }
     for (y = 0; y < 140; y++)
     {


### PR DESCRIPTION
## Bug
`GetFeebasTiles` (the Feebas-highlight feature) rewrote vanilla Emerald's Feebas spot
selection and turned its re-roll into a skip.

Vanilla picks each of the 6 spots by rolling a water-tile index and **re-rolling** on
1–3 (the inaccessible tiles at the top of Route 119; the first usable tile is 4). The
rewrite instead **skipped the array assignment** on a 1–3 roll while still advancing to
the next spot:

```c
if (randomTile == 0 || randomTile > 3)   // false for 1–3 → slot left unset
    feebasTiles[nFeebasGenerated] = randomTile;
```
That leaves feebasTiles[i] holding stack garbage, which usually matches no water tile,
so the spot silently fails to place. Effects: occasionally fewer than 6 live Feebas
tiles; a stale tile kept after a re-generation (map load / Dewford trend / Devon Scope
toggle); and the gFeebasTiles entry left {0,0}, which HighlightFeebasTiles then
pokes at map corner (0,0). ~4% of generations lose a spot.

Fix

Restore vanilla's re-roll so all 6 slots always get a real tile:

```
while (nFeebasGenerated < NUM_FEEBAS_SPOTS)
{
    u32 randomTile = FeebasRandom() % nWaterTiles;
    if (randomTile == 0)
        randomTile = nWaterTiles;
    if (randomTile <= 3)
        continue;
    feebasTiles[nFeebasGenerated++] = randomTile;
}
```
Duplicate tiles remain possible, exactly as in vanilla.