### PR TITLE
Fix party menu message box rendering a transparent interior for a few frames

### DIFF
--- a/src/party_menu.c
+++ b/src/party_menu.c
@@ -2152,6 +2152,16 @@ static void InitPartyMenuWindows(u8 layout)
     LoadUserWindowBorderGfx(0, 0x4F, BG_PLTT_ID(13));
     LoadPalette(GetOverworldTextboxPalettePtr(), BG_PLTT_ID(14), PLTT_SIZE_4BPP);
     LoadPalette(gStandardMenuPalette, BG_PLTT_ID(15), PLTT_SIZE_4BPP);
+    // Pre-seed WIN_MSG's tile region with its dark interior fill. VRAM was
+    // zeroed when the menu opened, and PrintMessage() only delivers the
+    // interior via the text printer's per-frame GFX copy - a separate DMA
+    // request from the scheduled BG2 tilemap copy that maps the frame. If a
+    // deferred tilemap copy landed a VBlank before the message's first GFX
+    // copy, the box showed borders around a transparent middle for a few
+    // frames. Seeding the fill here (screen still faded) makes the interior
+    // always opaque.
+    FillWindowPixelBuffer(WIN_MSG, PIXEL_FILL(1));
+    CopyWindowToVram(WIN_MSG, COPYWIN_GFX);
 }
 
 static void CreateCancelConfirmWindows(bool8 chooseHalf)


### PR DESCRIPTION
This is a bug I had in Veritas that seemed to be also present in Enhanced. Feel free to discard the fix if you don't see it as warranted.

## Bug

When using an item on a party member, the bottom message box can render with only its
border and a see-through middle for a few frames before the text appears.

## Cause

The box's **frame** (BG2 tilemap) and its **interior fill** (window tile GFX) travel to
VRAM by two independent DMA requests: `PrintMessage` draws its frame with
`copyToVram = FALSE`, delegating the interior's copy to the text printer's per-frame
`COPYWIN_GFX`. The party menu also zeroes all of VRAM on open, so the message window's
tiles are transparent until that first GFX copy lands. Under DMA-queue pressure (VBlank
40 KiB cap / VCOUNT bail), a deferred BG2 tilemap copy can map the box one or more
VBlanks before its GFX arrives, borders around an empty middle until the printer's next
copy. Intermittent, item-use-specific, lasts a few frames.

## Fix

Pre-seed the message window's `PIXEL_FILL(1)` interior at window init, while the screen
is still faded. Whichever request lands first afterwards, the interior is already opaque.
One extra one-time copy, no timing assumptions. Single file, `src/party_menu.c`.