### PR TITLE
Add a Windows modern-build workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ LIBPATH := -L ../../tools/agbcc/lib
 LIB := $(LIBPATH) -lgcc -lc -L../../libagbsyscall -lagbsyscall
 else
 CC1              = $(shell $(PATH_MODERNCC) --print-prog-name=cc1) -quiet
-override CFLAGS += -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
+override CFLAGS += -std=gnu17 -mthumb -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
 ROM := $(MODERN_ROM_NAME)
 OBJ_DIR := $(MODERN_OBJ_DIR_NAME)
 LIBPATH := -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libgcc.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libnosys.a))" -L "$(dir $(shell $(PATH_MODERNCC) -mthumb -print-file-name=libc.a))"
@@ -115,6 +115,9 @@ LIB := $(LIBPATH) -lc -lnosys -lgcc -L../../libagbsyscall -lagbsyscall
 endif
 
 CPPFLAGS := -iquote include -iquote $(GFLIB_SUBDIR) -Wno-trigraphs -DMODERN=$(MODERN)
+ifeq ($(MODERN),1)
+CPPFLAGS += -std=gnu17
+endif
 ifneq ($(MODERN),1)
 CPPFLAGS += -I tools/agbcc/include -I tools/agbcc -nostdinc -undef
 endif
@@ -295,7 +298,7 @@ $(C_BUILDDIR)/record_mixing.o: CFLAGS += -ffreestanding
 $(C_BUILDDIR)/librfu_intr.o: CC1 := tools/agbcc/bin/agbcc_arm$(EXE)
 $(C_BUILDDIR)/librfu_intr.o: CFLAGS := -O2 -mthumb-interwork -quiet
 else
-$(C_BUILDDIR)/librfu_intr.o: CFLAGS := -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
+$(C_BUILDDIR)/librfu_intr.o: CFLAGS := -std=gnu17 -mthumb-interwork -O2 -mabi=apcs-gnu -mtune=arm7tdmi -march=armv4t -fno-toplevel-reorder -Wno-pointer-to-int-cast
 endif
 
 ifeq ($(DINFO),1)

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,46 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('modern', 'default', 'compare', 'clean', 'clean-tools', 'tidymodern')]
+    [string]$Target = 'modern',
+
+    [ValidateRange(1, 256)]
+    [int]$Jobs = [Environment]::ProcessorCount
+)
+
+$ErrorActionPreference = 'Stop'
+
+$candidateRoots = @(
+    $env:MSYS2_ROOT,
+    'C:\msys64',
+    (Join-Path $env:LOCALAPPDATA 'Programs\msys64'),
+    (Join-Path $env:LOCALAPPDATA 'MSYS2')
+) | Where-Object { $_ }
+
+$msysRoot = $candidateRoots |
+    Where-Object { Test-Path (Join-Path $_ 'usr\bin\bash.exe') } |
+    Select-Object -First 1
+
+if (-not $msysRoot) {
+    throw 'MSYS2 was not found. Install it and the UCRT64 build dependencies described in INSTALL.md.'
+}
+
+$bash = Join-Path $msysRoot 'usr\bin\bash.exe'
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+$env:PELE_WINDOWS_ROOT = $repoRoot
+$unixRoot = (& $bash -lc 'cygpath -u -- "$PELE_WINDOWS_ROOT"').Trim()
+
+if (-not $unixRoot) {
+    throw "MSYS2 could not translate the repository path: $repoRoot"
+}
+
+$env:PELE_UNIX_ROOT = $unixRoot
+$makeGoal = if ($Target -eq 'default') { '' } else { $Target }
+$command = 'export PATH=/ucrt64/bin:/usr/bin:$PATH; cd "$PELE_UNIX_ROOT"; make ' + $makeGoal + " -j$Jobs"
+
+$env:MSYSTEM = 'UCRT64'
+$env:CHERE_INVOKING = '1'
+& $bash -lc $command
+
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}

--- a/tools/mapjson/json11.cpp
+++ b/tools/mapjson/json11.cpp
@@ -19,6 +19,7 @@
 
 #include "json11.h"
 #include <cassert>
+#include <cstdint>
 #include <cmath>
 #include <cstdlib>
 #include <cstdio>


### PR DESCRIPTION
## Summary

Adds a checked-in PowerShell wrapper for modern builds on Windows. It locates MSYS2, enters the UCRT64 environment, translates the repository path, places the host and ARM toolchains on `PATH`, and invokes the requested Make target with configurable parallelism.

The modern GCC/preprocessor path now explicitly uses GNU C17, and mapjson includes `<cstdint>` for current host compilers.

## Usage

```powershell
powershell -ExecutionPolicy Bypass -File scripts/build.ps1 -Target modern
```

Supported targets are `modern`, `default`, `compare`, `clean`, `clean-tools`, and `tidymodern`. `-Jobs` defaults to the host processor count.

## Validation

- `scripts/build.ps1 -Target modern`: passed
- Produced `Modern_Base_-_Pokemon_Emerald_Legacy_Enhanced.gba`
- `git diff --check`: passed

This PR is intentionally independent of the Shining Trial gameplay PR so it can be reviewed and cherry-picked on its own.